### PR TITLE
修改Activity托管Fragment的方式

### DIFF
--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -2,7 +2,7 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
-      <module fileurl="file://$PROJECT_DIR$/MVPTest.iml" filepath="$PROJECT_DIR$/MVPTest.iml" />
+      <module fileurl="file://$PROJECT_DIR$/MVPDemo.iml" filepath="$PROJECT_DIR$/MVPDemo.iml" />
       <module fileurl="file://$PROJECT_DIR$/app/app.iml" filepath="$PROJECT_DIR$/app/app.iml" />
     </modules>
   </component>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/app/src/main/java/com/juhezi/mvptest/SingleFragmentActivity.java
+++ b/app/src/main/java/com/juhezi/mvptest/SingleFragmentActivity.java
@@ -1,0 +1,53 @@
+package com.juhezi.mvptest;
+
+import android.os.Bundle;
+import android.support.annotation.LayoutRes;
+import android.support.annotation.Nullable;
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentManager;
+import android.support.v7.app.AppCompatActivity;
+
+/**
+ * Author: Inno Fang
+ * Time: 2017/1/9 00:02
+ * Description:
+ * Activity 托管 Fragment 模板
+ */
+
+public abstract class SingleFragmentActivity extends AppCompatActivity{
+
+    protected abstract Fragment createFragment();
+
+    protected void init(){}
+    /**
+     * 可以设置一个只有FrameLayout的xml文件作为默认的Fragment容器，
+     * 若子类有更好的容器可以重写该方法，若没有则可以直接用默认的容器
+     * 假设布局文件名字为activity_fragment.xml
+     */
+    @LayoutRes
+    protected int getLayoutResId(){
+        // return R.layout.activity_fragment;
+        /**
+         * 因为没有创建activity_fragment.xml
+         * 所以暂时用现有的布局文件
+         */
+        return R.layout.sign_in_act;
+    }
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(getLayoutResId());
+
+        FragmentManager fm = getSupportFragmentManager();
+        Fragment fragment = fm.findFragmentById(R.id.fragment_container);
+
+        if (null == fragment) {
+            fragment = createFragment();
+            fm.beginTransaction()
+                    .add(R.id.fragment_container, fragment)
+                    .commit();
+        }
+        init();
+    }
+}

--- a/app/src/main/java/com/juhezi/mvptest/sign_in/SignInActivity.java
+++ b/app/src/main/java/com/juhezi/mvptest/sign_in/SignInActivity.java
@@ -1,49 +1,40 @@
 package com.juhezi.mvptest.sign_in;
 
-import android.net.Uri;
+import android.support.v4.app.Fragment;
 import android.support.v7.app.ActionBar;
-import android.support.v7.app.AppCompatActivity;
-import android.os.Bundle;
 import android.support.v7.widget.Toolbar;
 
-import com.google.android.gms.appindexing.Action;
-import com.google.android.gms.appindexing.AppIndex;
-import com.google.android.gms.appindexing.Thing;
-import com.google.android.gms.common.api.GoogleApiClient;
 import com.juhezi.mvptest.R;
-import com.juhezi.mvptest.model.ResponseImpl;
-import com.juhezi.mvptest.model.local.LocalResponse;
-import com.juhezi.mvptest.model.remote.RemoteResponse;
+import com.juhezi.mvptest.SingleFragmentActivity;
 
-public class SignInActivity extends AppCompatActivity {
+/**
+ * 简化Activity托管Fragment
+ * 只需要重写三个方法即可
+ */
+
+public class SignInActivity extends SingleFragmentActivity{
 
     private Toolbar mToolbar;
     private ActionBar mActionBar;
 
-    private SignInFragment mFragment;
-    private SignInPresenter mPresenter;
-
     @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        setContentView(R.layout.sign_in_act);
-
-        initActionBar();
-
-        initFragment();
+    protected int getLayoutResId() {
+        // 若子类有更好的容器视图则可以返回新的容器布局文件
+         return R.layout.sign_in_act;
     }
 
-    private void initFragment() {
-        mFragment = (SignInFragment) getSupportFragmentManager().findFragmentById(R.id.rl_sign_in_frag);
-        if (mFragment == null) {
-            mFragment = new SignInFragment();
-            getSupportFragmentManager()
-                    .beginTransaction()
-                    .add(R.id.rl_sign_in_frag, mFragment)
-                    .commit();
-        }
-        mPresenter = new SignInPresenter(mFragment,
-                new ResponseImpl(new LocalResponse(), new RemoteResponse()));
+    @Override
+    protected Fragment createFragment() {
+        // 创建指定Fragment
+        return SignInFragment.newInstance();
+    }
+
+    @Override
+    protected void init() {
+        super.init();
+        // 这里将presenter的初始化移到了Fragment
+        initActionBar();
+
     }
 
     private void initActionBar() {
@@ -52,5 +43,6 @@ public class SignInActivity extends AppCompatActivity {
         mActionBar = getSupportActionBar();
         mActionBar.setHomeButtonEnabled(true);
     }
+
 
 }

--- a/app/src/main/java/com/juhezi/mvptest/sign_in/SignInFragment.java
+++ b/app/src/main/java/com/juhezi/mvptest/sign_in/SignInFragment.java
@@ -11,7 +11,9 @@ import android.widget.EditText;
 import android.widget.Toast;
 
 import com.juhezi.mvptest.R;
-import com.juhezi.mvptest.util.Action;
+import com.juhezi.mvptest.model.ResponseImpl;
+import com.juhezi.mvptest.model.local.LocalResponse;
+import com.juhezi.mvptest.model.remote.RemoteResponse;
 
 /**
  * Created by qiao1 on 2017/1/7.
@@ -26,6 +28,13 @@ public class SignInFragment extends Fragment implements SignInContract.View {
     private EditText mEtPasswd;
     private Button mBtnSignIn;
 
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        mPresenter = new SignInPresenter(this,
+                new ResponseImpl(new LocalResponse(), new RemoteResponse()));
+    }
+
     @Nullable
     @Override
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
@@ -33,6 +42,7 @@ public class SignInFragment extends Fragment implements SignInContract.View {
         mEtPasswd = (EditText) rootView.findViewById(R.id.et_username);
         mEtUsername = (EditText) rootView.findViewById(R.id.et_passwd);
         mBtnSignIn = (Button) rootView.findViewById(R.id.btn_sign_in);
+
         initEvent();
         return rootView;
     }
@@ -83,5 +93,13 @@ public class SignInFragment extends Fragment implements SignInContract.View {
     @Override
     public void showToast(String message) {
         Toast.makeText(getContext(), message, Toast.LENGTH_SHORT).show();
+    }
+
+    /**
+     *
+     * @return 返回一个指定的Fragment实例
+     */
+    public static Fragment newInstance() {
+        return new SignInFragment();
     }
 }

--- a/app/src/main/res/layout/sign_in_act.xml
+++ b/app/src/main/res/layout/sign_in_act.xml
@@ -14,7 +14,7 @@
         android:background="@color/colorPrimary" />
 
     <RelativeLayout
-        android:id="@+id/rl_sign_in_frag"
+        android:id="@+id/fragment_container"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
 


### PR DESCRIPTION
做出如下两点修改：

 + 创建了一个SingleFramgmentActivity类专门用来便于Activity托管Fragment，只需重写三个方法即可
     - `getLayoutResId()` 只需返回布局文件的值即可，如`R.layout.sign_in_act`
     - `createFragment()`  返回指定要托管的实例即可，这里为了体现封装性，在Fragment写了一个`newInstance()`的静态方法，专门用来返回Fragment的实例
     - 'init()' 初始化，如ActionBar，ToolBar的初始化，若没有也可以不写
 + 将Presenter的初始化移到Fragment